### PR TITLE
HD-1325: Integrate auth plugin code for Altiscale 4.0

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1954,6 +1954,24 @@ public class HiveConf extends Configuration {
         "hive.security.authenticator.manager,hive.security.authorization.manager,hive.users.in.admin.role",
         "Comma separated list of configuration options which are immutable at runtime"),
 
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_USED("hive.server2.kerberos.custom.authentication.used", false,
+        "Set this to true for using custom authentication class with Kerberos in HiveServer2."),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS("hive.server2.kerberos.custom.authentication.class", null,
+        "Custom authentication class with Kerberos. Used when property\n" +
+        "'hive.server2.authentication' is set to 'KERBEROS' and" +
+        "'hive.server2.kerberos.custom.authentication.used' is set to 'true'.\n" +
+        "Provided class must be a proper implementation of the interface\n" +
+        "org.apache.hadoop.hive.thrift.KrbCustomAuthenticationProvider.\n" +
+        "Hiveserver2 will call its Authenticate(user, passed) method to authenticate requests.\n" +
+        "The implementation may optionally implement Hadoop's\n" +
+        "org.apache.hadoop.conf.Configurable class to grab Hive's Configuration object."),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_PORT("hive.server2.kerberos.custom.authentication.port", 10010,
+        "Port number of HiveServer2 for using custom authenticaiton class with Kerberos."),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MIN_WORKER_THREADS("hive.server2.kerberos.custom.authentication.min.worker.threads", 5,
+        "Minimum number of custom authentication class worker threads with Kerberos"),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MAX_WORKER_THREADS("hive.server2.kerberos.custom.authentication.max.worker.threads", 500,
+        "Maximum number of custom authentication class worker threads with Kerberos"),
+
     // If this is set all move tasks at the end of a multi-insert query will only begin once all
     // outputs are ready
     HIVE_MULTI_INSERT_MOVE_TASKS_SHARE_DEPENDENCIES(

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1971,6 +1971,12 @@ public class HiveConf extends Configuration {
         "Minimum number of custom authentication class worker threads with Kerberos"),
     HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MAX_WORKER_THREADS("hive.server2.kerberos.custom.authentication.max.worker.threads", 500,
         "Maximum number of custom authentication class worker threads with Kerberos"),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED("hive.server2.kerberos.custom.authentication.SSL.used", false,
+         "Set this to true for using SSL encryption for SASL(PLAIN) with Kerberos in HiveServer2."),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PATH("hive.server2.kerberos.custom.authentication.ssl.keystore.path", "",
+         "SSL certificate keystore location for using SSL encryption for SASL(PLAIN) with Kerberos."),
+    HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PASSWORD("hive.server2.kerberos.custom.authentication.ssl.keystore.password", "",
+         "SSL certificate keystore password for using SSL encryption for SASL(PLAIN) with Kerberos."),
 
     // If this is set all move tasks at the end of a multi-insert query will only begin once all
     // outputs are ready

--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestJdbWithCustomAuthWithKerberos.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestJdbWithCustomAuthWithKerberos.java
@@ -1,0 +1,149 @@
+package org.apache.hive.minikdc;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.net.URLEncoder;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.security.sasl.AuthenticationException;
+
+import junit.framework.Assert;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.MetaStoreUtils;
+import org.apache.hadoop.hive.thrift.KrbCustomAuthenticationProvider;
+import org.apache.hive.jdbc.TestSSL;
+import org.apache.hive.jdbc.miniHS2.MiniHS2;
+import org.apache.hive.jdbc.miniHS2.MiniHS2.MiniClusterType;
+import org.apache.hive.service.auth.PasswdAuthenticationProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestJdbWithCustomAuthWithKerberos {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSSL.class);
+  private static Integer KERBEROS_CUSTOM_PORT;
+  private static final String HS2_BINARY_MODE = "binary";
+
+  private MiniHiveKdc miniHiveKdc;
+  private MiniHS2 miniHS2 = null;
+  private static HiveConf hiveConf = new HiveConf();
+  private Connection hs2Conn = null;
+  private Map<String, String> confOverlay;
+
+  @BeforeClass
+  public static void beforeTest() throws Exception {
+    Class.forName(MiniHS2.getJdbcDriverName());
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    DriverManager.setLoginTimeout(0);
+    KERBEROS_CUSTOM_PORT = MetaStoreUtils.findFreePort();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (hs2Conn != null) {
+      try {
+        hs2Conn.close();
+      } catch (Exception e) {
+        // Ignore shutdown errors since there are negative tests
+      }
+    }
+    if (miniHS2 != null && miniHS2.isStarted()) {
+      miniHS2.stop();
+    }
+  }
+
+  @Test
+  public void testKerberosAuthentication() throws Exception {
+    setCustomAuthWithKrbOverlay();
+    startMiniHS2();
+
+    // JDBC connection to HiveServer2 with Kerberos
+    hs2Conn = DriverManager.getConnection(miniHS2.getJdbcURL());
+    hs2Conn.close();
+  }
+
+  @Test
+  public void testCustomAuthenticationOverPlainWithKerberos() throws Exception {
+    setCustomAuthWithKrbOverlay();
+    startMiniHS2();
+
+    // JDBC connection with ID/PASSWD without SSL with Kerberos
+    String url = "jdbc:hive2://" + miniHS2.getHost() + ":" + KERBEROS_CUSTOM_PORT + "/default";
+
+    // wrong ID/PASSWD
+    try {
+      hs2Conn = DriverManager.getConnection(url, "wronguser", "pwd");
+    } catch(SQLException e) {
+      assertNotNull(e.getMessage());
+      assertTrue(e.getMessage(), e.getMessage().contains("Peer indicated failure: Error validating the login"));
+    }
+
+    // success ID/PASSWD
+    hs2Conn = DriverManager.getConnection(url, "hiveuser", "hive");
+    hs2Conn.close();
+
+    System.out.println(">>> PASSED testCustomAuthenticationOverPlain");
+    hs2Conn.close();
+  }
+
+
+  public static class SimpleCustomAuthWithKerberosProviderImpl implements KrbCustomAuthenticationProvider {
+
+    private Map<String, String> userMap = new HashMap<String, String>();
+
+    public SimpleCustomAuthWithKerberosProviderImpl() {
+      init();
+    }
+
+    private void init(){
+      userMap.put("hiveuser","hive");
+    }
+
+    @Override
+    public void Authenticate(String user, String password) throws AuthenticationException {
+      if(!userMap.containsKey(user)){
+        throw new AuthenticationException("Invalid user : "+user);
+      }
+      if(!userMap.get(user).equals(password)){
+        throw new AuthenticationException("Invalid passwd : "+password);
+      }
+    }
+  }
+
+
+  private void setCustomAuthWithKrbOverlay() {
+    confOverlay = new HashMap<String, String>();
+    confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_USED.varname, "true");
+    confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS.varname,
+      "org.apache.hive.minikdc.TestJdbWithCustomAuthWithKerberos$SimpleCustomAuthWithKerberosProviderImpl");
+    confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_PORT.varname, KERBEROS_CUSTOM_PORT.toString());
+    confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MIN_WORKER_THREADS.varname,
+      "3");
+    confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MAX_WORKER_THREADS.varname,
+      "5");
+  }
+
+  private void startMiniHS2() {
+    try {
+      miniHiveKdc = MiniHiveKdc.getMiniHiveKdc(hiveConf);
+      miniHS2 = MiniHiveKdc.getMiniHS2WithKerb(miniHiveKdc, hiveConf);
+      miniHS2.start(confOverlay);
+    } catch(Exception e) {
+		  assertNotNull(e.getMessage());
+    }
+  }
+}

--- a/service/src/java/org/apache/hive/service/auth/HiveAuthFactory.java
+++ b/service/src/java/org/apache/hive/service/auth/HiveAuthFactory.java
@@ -176,6 +176,26 @@ public class HiveAuthFactory {
     }
   }
 
+  /**
+   * Returns an authentication factory for HiveServer2 running
+   * that verifies the ID/PASSWORD using custom class over SSL with Kerberos
+   * @return
+   * @throws LoginException
+   */
+  public TTransportFactory getAuthPlainTransFactory() throws LoginException {
+    TTransportFactory transportFactory;
+    if (authTypeStr.equalsIgnoreCase(AuthTypes.KERBEROS.getAuthName())) {
+      try {
+        transportFactory = saslServer.createPlainTransportFactory(getSaslProperties());
+      } catch (TTransportException e) {
+        throw new LoginException(e.getMessage());
+      }
+    } else {
+      throw new LoginException("Unsupported authentication type " + authTypeStr);
+    }
+    return transportFactory;
+  }
+
   public String getRemoteUser() {
     return saslServer == null ? null : saslServer.getRemoteUser();
   }

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
@@ -170,7 +170,23 @@ public class ThriftBinaryCLIService extends ThriftCLIService {
      TProcessorFactory processorFactory = hiveAuthFactory.getAuthProcFactory(service);
      TServerSocket customKrbSocket = null;
 
-     customKrbSocket = HiveAuthFactory.getServerSocket(hiveHost, customPortNum);
+     if (!hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED)) {
+       customKrbSocket = HiveAuthFactory.getServerSocket(hiveHost, customPortNum);
+     } else {
+       List<String> sslVersionBlacklist = new ArrayList<String>();
+       for (String sslVersion : hiveConf.getVar(ConfVars.HIVE_SSL_PROTOCOL_BLACKLIST).split(",")) {
+         sslVersionBlacklist.add(sslVersion);
+       }
+       String keyStorePath = hiveConf.getVar(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PATH).trim();
+       if (keyStorePath.isEmpty()) {
+         throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PATH.varname +
+         " Not configured for SSL connection");
+       }
+       String keyStorePassword = ShimLoader.getHadoopShims().getPassword(hiveConf,
+           HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PASSWORD.varname);
+       customKrbSocket = HiveAuthFactory.getServerSSLSocket(hiveHost, customPortNum,
+         keyStorePath, keyStorePassword, sslVersionBlacklist);
+     }
 
      // Server args
      int maxMessageSize = hiveConf.getIntVar(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_MAX_MESSAGE_SIZE);

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
@@ -30,18 +30,30 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.hive.service.auth.HiveAuthFactory;
 import org.apache.hive.service.cli.CLIService;
+import org.apache.hive.service.server.HiveServer2;
 import org.apache.hive.service.server.ThreadFactoryWithGarbageCleanup;
 import org.apache.thrift.TProcessorFactory;
 import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportFactory;
 
 
 public class ThriftBinaryCLIService extends ThriftCLIService {
+  TServer customKrbServer;
 
   public ThriftBinaryCLIService(CLIService cliService) {
     super(cliService, ThriftBinaryCLIService.class.getSimpleName());
+  }
+
+  @Override
+  public synchronized void stop() {
+    if (customKrbServer != null) {
+        customKrbServer.stop();
+      LOG.info("Thrift SASL(PLAIN) over SSL with Kerberos server has stopped");
+    }
+    super.stop();
   }
 
   @Override
@@ -96,6 +108,29 @@ public class ThriftBinaryCLIService extends ThriftCLIService {
       String msg = "Starting " + ThriftBinaryCLIService.class.getSimpleName() + " on port "
           + portNum + " with " + minWorkerThreads + "..." + maxWorkerThreads + " worker threads";
       LOG.info(msg);
+
+      // New thread : Custom authentication with Kerberos thread
+      final ThriftCLIService svc = this;
+
+      if (!HiveServer2.isHTTPTransportMode(hiveConf)
+          && isKerberosAuthMode()
+          && hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_USED)) {
+        Thread t = new Thread() {
+          @Override
+          public void run() {
+            try {
+              startCustomWithKerberos(hiveConf,
+                svc, hiveHost, customKrbServer);
+            } catch (Throwable t) {
+              LOG.error(
+                "Failure ThriftBinaryCLIService custom authentication with Kerberos listening on "
+                + hiveHost + ": " + t.getMessage());
+            }
+          }
+        };
+        t.start();
+      }
+
       server.serve();
     } catch (Throwable t) {
       LOG.fatal(
@@ -105,4 +140,63 @@ public class ThriftBinaryCLIService extends ThriftCLIService {
     }
   }
 
+  // Custom authentication class with Kerberos thread
+  private static void startCustomWithKerberos(
+   final HiveConf hiveConf,
+   final ThriftCLIService service,
+   final String hiveHost,
+   TServer customKrbServer) throws Exception {
+
+   try {
+     int minThreads = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MIN_WORKER_THREADS);
+     int maxThreads = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_MAX_WORKER_THREADS);
+
+     // custom authenticatino class with Kerberos Server thread pool
+     String threadPoolName = "HiveServer2-custom-with-Krb-Handler-Pool";
+     ExecutorService executorService = new ThreadPoolExecutor(minThreads, maxThreads,
+         service.workerKeepAliveTime, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
+         new ThreadFactoryWithGarbageCleanup(threadPoolName));
+
+     int customPortNum;
+     String portString = System.getenv("HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_PORT");
+     if (portString != null) {
+       customPortNum = Integer.valueOf(portString);
+     } else {
+       customPortNum = hiveConf.getIntVar(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_PORT);
+     }
+
+     HiveAuthFactory hiveAuthFactory = new HiveAuthFactory(hiveConf);
+     TTransportFactory transportFactory = hiveAuthFactory.getAuthPlainTransFactory();
+     TProcessorFactory processorFactory = hiveAuthFactory.getAuthProcFactory(service);
+     TServerSocket customKrbSocket = null;
+
+     customKrbSocket = HiveAuthFactory.getServerSocket(hiveHost, customPortNum);
+
+     // Server args
+     int maxMessageSize = hiveConf.getIntVar(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_MAX_MESSAGE_SIZE);
+     int requestTimeout = (int) hiveConf.getTimeVar(
+         HiveConf.ConfVars.HIVE_SERVER2_THRIFT_LOGIN_TIMEOUT, TimeUnit.SECONDS);
+     int beBackoffSlotLength = (int) hiveConf.getTimeVar(
+         HiveConf.ConfVars.HIVE_SERVER2_THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH, TimeUnit.MILLISECONDS);
+     TThreadPoolServer.Args sargs = new TThreadPoolServer.Args(customKrbSocket)
+         .processorFactory(processorFactory).transportFactory(transportFactory)
+         .protocolFactory(new TBinaryProtocol.Factory())
+         .inputProtocolFactory(new TBinaryProtocol.Factory(true, true, maxMessageSize, maxMessageSize))
+         .requestTimeout(requestTimeout).requestTimeoutUnit(TimeUnit.SECONDS)
+         .beBackoffSlotLength(beBackoffSlotLength).beBackoffSlotLengthUnit(TimeUnit.MILLISECONDS)
+         .executorService(executorService);
+
+     // TCP Server
+     customKrbServer = new TThreadPoolServer(sargs);
+     String msg = "Starting " + ThriftBinaryCLIService.class.getSimpleName()
+         + " custom authentication with Kerberos listening on "
+         + customPortNum + " with " + minThreads + "..." + maxThreads + " worker threads";
+     LOG.info(msg);
+
+     customKrbServer.serve();
+   } catch (Throwable t) {
+     LOG.fatal(
+       "Error starting HiveServer2: could not start custom authentication with Kerberos", t);
+   }
+ }
 }

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
@@ -733,7 +733,7 @@ public abstract class ThriftCLIService extends AbstractService implements TCLISe
     return proxyUser;
   }
 
-  private boolean isKerberosAuthMode() {
+  protected boolean isKerberosAuthMode() {
     return cliService.getHiveConf().getVar(ConfVars.HIVE_SERVER2_AUTHENTICATION)
         .equalsIgnoreCase(HiveAuthFactory.AuthTypes.KERBEROS.toString());
   }

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
@@ -517,7 +517,7 @@ public class ThriftHttpServlet extends TServlet {
     return authHeaderBase64String;
   }
 
-  private boolean isKerberosAuthMode(String authType) {
+  protected boolean isKerberosAuthMode(String authType) {
     return authType.equalsIgnoreCase(HiveAuthFactory.AuthTypes.KERBEROS.toString());
   }
 

--- a/shims/common/src/main/java/org/apache/hadoop/hive/thrift/DefaultKrbCustomAuthenticationProviderImpl.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/thrift/DefaultKrbCustomAuthenticationProviderImpl.java
@@ -1,0 +1,16 @@
+package org.apache.hadoop.hive.thrift;
+
+import javax.security.sasl.AuthenticationException;
+
+public class DefaultKrbCustomAuthenticationProviderImpl implements KrbCustomAuthenticationProvider {
+
+ /**
+  * This class will be called when you set
+  * hive.server2.authentication=KERBEROS and hive.server2.kerberos.custom.authentication.used = true
+  * with hive.server2.kerberos.custom.authentication.class=<class name> on hive-site.xml
+  **/
+  @Override
+  public void Authenticate(String user, String password) throws AuthenticationException {
+    throw new AuthenticationException("Unsupported authentication method on Kerberos environment");
+  }
+}

--- a/shims/common/src/main/java/org/apache/hadoop/hive/thrift/HadoopThriftAuthBridge.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/thrift/HadoopThriftAuthBridge.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -32,6 +33,7 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthenticationException;
 import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.RealmChoiceCallback;
@@ -322,9 +324,12 @@ public class HadoopThriftAuthBridge {
         "hive.cluster.delegation.token.store.zookeeper.acl";
     public static final String DELEGATION_TOKEN_STORE_ZK_ZNODE_DEFAULT =
         "/hivedelegation";
+    public static final String HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS =
+        "hive.server2.kerberos.custom.authentication.class";
 
     protected final UserGroupInformation realUgi;
     protected DelegationTokenSecretManager secretManager;
+    Configuration thriftConf;
 
     public Server() throws TTransportException {
       try {
@@ -361,9 +366,9 @@ public class HadoopThriftAuthBridge {
 
     /**
      * Create a TTransportFactory that, upon connection of a client socket,
-     * negotiates a Kerberized SASL transport. The resulting TTransportFactory
-     * can be passed as both the input and output transport factory when
-     * instantiating a TThreadPoolServer, for example.
+     * negotiates a Kerberized SASL transport with KERBEROS and DIGEST mechanisms.
+     * The resulting TTransportFactory can be passed as both the input and output
+     * transport factory when instantiating a TThreadPoolServer, for example.
      *
      * @param saslProps Map of SASL properties
      */
@@ -386,6 +391,32 @@ public class HadoopThriftAuthBridge {
       transFactory.addServerDefinition(AuthMethod.DIGEST.getMechanismName(),
           null, SaslRpcServer.SASL_DEFAULT_REALM,
           saslProps, new SaslDigestCallbackHandler(secretManager));
+
+      return new TUGIAssumingTransportFactory(transFactory, realUgi);
+    }
+
+    /**
+     * Create a TTransportFactory that, upon connection of a client socket,
+     * negotiates a Kerberized SASL transport with PLAIN mechanism.
+     * The resulting TTransportFactory can be passed as both the input and output
+     * transport factory when instantiating a TThreadPoolServer, for example.
+     *
+     * @param saslProps Map of SASL properties
+     */
+    public TTransportFactory createPlainTransportFactory(Map<String, String> saslProps)
+        throws TTransportException {
+      // Parse out the kerberos principal, host, realm.
+      String kerberosName = realUgi.getUserName();
+      final String names[] = SaslRpcServer.splitKerberosName(kerberosName);
+      if (names.length != 3) {
+        throw new TTransportException("Kerberos principal should have 3 parts: " + kerberosName);
+      }
+
+      TSaslServerTransport.Factory transFactory = new TSaslServerTransport.Factory();
+      // Add for custom class on kerberized cluster
+      transFactory.addServerDefinition("PLAIN",
+          "NONE", null, new HashMap<String, String>(),
+          new SaslCustomServerCallbackHandler(thriftConf));
 
       return new TUGIAssumingTransportFactory(transFactory, realUgi);
     }
@@ -446,6 +477,7 @@ public class HadoopThriftAuthBridge {
           tokenMaxLifetime,
           tokenRenewInterval,
           tokenGcInterval, dts);
+      thriftConf = new Configuration(conf);
       secretManager.startThreads();
     }
 
@@ -545,6 +577,64 @@ public class HadoopThriftAuthBridge {
 
     public String getRemoteUser() {
       return remoteUser.get();
+    }
+
+    /** CallbackHandler for Server Custom authentication class with Kerberos */
+    // The client mechanism uses PLAIN on SASL API with Kerberos.
+    // Therefore, it has the similar format with PlainServerCallbackHandler.
+    static class SaslCustomServerCallbackHandler implements CallbackHandler {
+      private KrbCustomAuthenticationProvider customProvider;
+
+      public SaslCustomServerCallbackHandler(Configuration conf) {
+        // Default custom class : It only allows CUSTOM authentication with Kerberos cluster
+        String customClassName = conf.get(
+          HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS,
+          "org.apache.hadoop.hive.thrift.DefaultKrbCustomAuthenticationProviderImpl");
+
+        try {
+          Class<? extends KrbCustomAuthenticationProvider> customHandlerClass =
+            Class.forName(customClassName).asSubclass(
+              KrbCustomAuthenticationProvider.class);
+          this.customProvider = ReflectionUtils.newInstance(customHandlerClass, conf);
+        } catch (ClassNotFoundException e) {
+          LOG.debug("Cannot find the custom authentication class: "
+            + customClassName);
+        }
+      }
+
+      @Override
+      public void handle(Callback[] callbacks) throws InvalidToken,
+      UnsupportedCallbackException {
+        String userName = null;
+        String userPassword = null;
+        AuthorizeCallback ac = null;
+
+        for (Callback callback : callbacks) {
+          if (callback instanceof AuthorizeCallback) {
+            ac = (AuthorizeCallback) callback;
+          } else if (callback instanceof NameCallback) {
+            NameCallback nc = (NameCallback) callback;
+            userName = nc.getName();
+          } else if (callback instanceof PasswordCallback) {
+            PasswordCallback pc = (PasswordCallback) callback;
+            userPassword = new String(pc.getPassword());
+          } else {
+            throw new UnsupportedCallbackException(callback,
+                "Unrecognized CUSTOM PLAIN Callback");
+          }
+        }
+
+        try {
+          // It calls custom Authentication module
+          this.customProvider.Authenticate(userName, userPassword);
+        } catch (AuthenticationException e) {
+          throw new InvalidToken("ERROR: ugi="+userName+" is not allowed");
+        }
+
+        if (ac != null) {
+          ac.setAuthorized(true);
+        }
+      }
     }
 
     /** CallbackHandler for SASL DIGEST-MD5 mechanism */
@@ -650,7 +740,6 @@ public class HadoopThriftAuthBridge {
         TSaslServerTransport saslTrans = (TSaslServerTransport)trans;
         SaslServer saslServer = saslTrans.getSaslServer();
         String authId = saslServer.getAuthorizationID();
-        authenticationMethod.set(AuthenticationMethod.KERBEROS);
         LOG.debug("AUTH ID ======>" + authId);
         String endUser = authId;
 
@@ -663,6 +752,12 @@ public class HadoopThriftAuthBridge {
           } catch (InvalidToken e) {
             throw new TException(e.getMessage());
           }
+        }
+        else if (saslServer.getMechanismName().equals("GSSAPI")) {
+          authenticationMethod.set(AuthenticationMethod.KERBEROS);
+        }
+        else if (saslServer.getMechanismName().equals("PLAIN")) {
+          LOG.debug("INFO: Request custom authentication module");
         }
         Socket socket = ((TSocket)(saslTrans.getUnderlyingTransport())).getSocket();
         remoteAddress.set(socket.getInetAddress());

--- a/shims/common/src/main/java/org/apache/hadoop/hive/thrift/KrbCustomAuthenticationProvider.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/thrift/KrbCustomAuthenticationProvider.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.hive.thrift;
+
+import javax.security.sasl.AuthenticationException;
+
+public interface KrbCustomAuthenticationProvider {
+  /**
+   * The Authenticate method is called by the thrift (HiveServer2, HiveMetastore) authentication layer
+   * to authenticate users for their requests (Server side).
+   * It has the same pattern with PasswordAuthenticationProvider.
+   * If a user is to be granted, return nothing/throw nothing.
+   * When a user is to be disallowed, throw an appropriate {@link AuthenticationException}.
+   *
+   * For an example implementation, see {@link LdapAuthenticationProviderImpl}.
+   *
+   * @param user - The username received over the connection request
+   * @param password - The password received over the connection request
+   * @throws AuthenticationException - When a user is found to be
+   * invalid by the implementation
+   */
+   void Authenticate(String user, String password) throws AuthenticationException;
+}


### PR DESCRIPTION
HIVE-10292: Support custom authentication with Kerberos
A. without SSL (plain connection)
B. over SSL (secure connection)
HIVE-10292 is not merged yet on HIVE Community.
In Altiscale, the same code was merged on HIVE 0.13. This is for HIVE 1.2.
