### PR TITLE
Adding Basic Auth in http transport channel with X-SAP-Hive-PasswdAut…

### DIFF
--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/MiniHiveKdc.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/MiniHiveKdc.java
@@ -200,9 +200,9 @@ public class MiniHiveKdc {
  public static MiniHS2 getMiniHS2WithKerb(MiniHiveKdc miniHiveKdc, HiveConf hiveConf,
      String authType) throws Exception {
    String hivePrincipal =
-       miniHiveKdc.getFullyQualifiedServicePrincipal(MiniHiveKdc.HIVE_SERVICE_PRINCIPAL);
+       miniHiveKdc.getFullyQualifiedServicePrincipal(MiniHiveKdc.HIVE_SERVICE_PRINCIPAL,null);
    String hiveKeytab = miniHiveKdc.getKeyTabFile(
-       miniHiveKdc.getServicePrincipalForUser(MiniHiveKdc.HIVE_SERVICE_PRINCIPAL));
+       miniHiveKdc.getServicePrincipalForUser(MiniHiveKdc.HIVE_SERVICE_PRINCIPAL,null));
 
    return new MiniHS2.Builder().withConf(hiveConf).withMiniKdc(hivePrincipal, hiveKeytab).
        withAuthenticationType(authType).build();

--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/MiniHiveKdc.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/MiniHiveKdc.java
@@ -200,9 +200,9 @@ public class MiniHiveKdc {
  public static MiniHS2 getMiniHS2WithKerb(MiniHiveKdc miniHiveKdc, HiveConf hiveConf,
      String authType) throws Exception {
    String hivePrincipal =
-       miniHiveKdc.getFullyQualifiedServicePrincipal(MiniHiveKdc.HIVE_SERVICE_PRINCIPAL,null);
+       miniHiveKdc.getFullyQualifiedServicePrincipal(MiniHiveKdc.HIVE_SERVICE_PRINCIPAL, null);
    String hiveKeytab = miniHiveKdc.getKeyTabFile(
-       miniHiveKdc.getServicePrincipalForUser(MiniHiveKdc.HIVE_SERVICE_PRINCIPAL,null));
+       miniHiveKdc.getServicePrincipalForUser(MiniHiveKdc.HIVE_SERVICE_PRINCIPAL, null));
 
    return new MiniHS2.Builder().withConf(hiveConf).withMiniKdc(hivePrincipal, hiveKeytab).
        withAuthenticationType(authType).build();

--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestJdbWithCustomAuthHttpWithKerberos.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestJdbWithCustomAuthHttpWithKerberos.java
@@ -1,8 +1,16 @@
 package org.apache.hive.minikdc;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
-import org.apache.hadoop.hive.thrift.KrbCustomAuthenticationProvider;
 import org.apache.hive.jdbc.TestSSL;
 import org.apache.hive.jdbc.miniHS2.MiniHS2;
 import org.junit.After;
@@ -12,178 +20,142 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.security.sasl.AuthenticationException;
-import java.io.File;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 public class TestJdbWithCustomAuthHttpWithKerberos {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSSL.class);
 
-    protected String getJDBCURL(boolean isSSL) {
-        if (isSSL) {
-            // JDBC connection with ID/PASSWD over SSL with Kerberos (Custom class)
-            String url = "jdbc:hive2://" + miniHS2.getHost() + ":" + miniHS2.getHttpPort() + "/default;transportMode=http;httpPath=cliservice;http.header.x-http-authtype=Basic"
-                    + ";ssl=true;sslTrustStore=" + dataFileDir + File.separator + TRUST_STORE_NAME
-                    + ";trustStorePassword=" + KEY_STORE_PASSWORD;
-            return url;
-        } else {
-            return "jdbc:hive2://" + miniHS2.getHost() + ":" + miniHS2.getHttpPort() + "/default;transportMode=http;httpPath=cliservice;http.header.x-http-authtype=Basic";
-        }
+  private static final String KEY_STORE_NAME = "keystore.jks";
+  protected static final String TRUST_STORE_NAME = "truststore.jks";
+  protected static final String KEY_STORE_PASSWORD = "HiveJdbc";
+  private static final String JAVA_TRUST_STORE_PROP = "javax.net.ssl.trustStore";
+  private static final String JAVA_TRUST_STORE_PASS_PROP = "javax.net.ssl.trustStorePassword";
 
+  private MiniHiveKdc miniHiveKdc;
+  protected static MiniHS2 miniHS2 = null;
+  private static Connection hs2Conn = null;
+  protected static HiveConf hiveConf = new HiveConf();
+  private Map<String, String> confOverlay;
+  protected String dataFileDir = hiveConf.get("test.data.files");
+
+  protected String getJdbcUrl(boolean isSsl) {
+    if (isSsl) {
+      // JDBC connection with ID/PASSWD over SSL with Kerberos (Custom class)
+      String url = "jdbc:hive2://" + miniHS2.getHost() + ":" + miniHS2.getHttpPort()
+          + "/default;transportMode=http;httpPath=cliservice;http.header.x-http-authtype=Basic"
+          + ";ssl=true;sslTrustStore=" + dataFileDir + File.separator + TRUST_STORE_NAME
+          + ";trustStorePassword=" + KEY_STORE_PASSWORD;
+      return url;
+    } else {
+      return "jdbc:hive2://" + miniHS2.getHost() + ":" + miniHS2.getHttpPort()
+          + "/default;transportMode=http;httpPath=cliservice;http.header.x-http-authtype=Basic";
+    }
+  }
+
+  @BeforeClass
+  public static void beforeTest() throws Exception {
+    Class.forName(MiniHS2.getJdbcDriverName());
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    DriverManager.setLoginTimeout(0);
+    hiveConf = new HiveConf();
+    hiveConf.setVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE, MiniHS2.HS2_HTTP_MODE);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (hs2Conn != null) {
+      hs2Conn.close();
+      hs2Conn = null;
+    }
+    if (miniHS2 != null && miniHS2.isStarted()) {
+      miniHS2.stop();
+      miniHS2.cleanup();
+    }
+    System.clearProperty(JAVA_TRUST_STORE_PROP);
+    System.clearProperty(JAVA_TRUST_STORE_PASS_PROP);
+  }
+
+  @Test
+  public void testKerberosAuthentication() throws Exception {
+    setCustomAuthWithKrbOverlay(false);
+    startMiniHS2();
+
+    // JDBC connection to HiveServer2 with Kerberos
+    hs2Conn = DriverManager.getConnection(miniHS2.getJdbcURL());
+  }
+
+  @Test
+  public void testCustomAuthenticationOverPlainWithKerberos() throws Exception {
+    setCustomAuthWithKrbOverlay(false);
+    startMiniHS2();
+
+    // JDBC connection with ID/PASSWD without SSL with Kerberos
+    String url = getJdbcUrl(false);
+
+    // wrong ID/PASSWD
+    try {
+      hs2Conn = DriverManager.getConnection(url, "wronguser", "pwd");
+    } catch (Exception e) {
+      assertNotNull(e.getMessage());
+      assertTrue(e.getMessage(), e.getMessage().contains("HTTP Response code: 401"));
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(TestSSL.class);
-    private static final String KEY_STORE_NAME = "keystore.jks";
-    protected static final String TRUST_STORE_NAME = "truststore.jks";
-    protected static final String KEY_STORE_PASSWORD = "HiveJdbc";
-    private static final String JAVA_TRUST_STORE_PROP = "javax.net.ssl.trustStore";
-    private static final String JAVA_TRUST_STORE_PASS_PROP = "javax.net.ssl.trustStorePassword";
+    // success ID/PASSWD
+    hs2Conn = DriverManager.getConnection(url, "hiveuser", "hive");
+  }
 
-    private MiniHiveKdc miniHiveKdc;
-    protected static MiniHS2 miniHS2 = null;
-    private static Connection hs2Conn = null;
-    protected static HiveConf hiveConf = new HiveConf();
-    private Map<String, String> confOverlay;
-    protected String dataFileDir = hiveConf.get("test.data.files");
+  @Test
+  public void testCustomAuthenticationOverSslWithKerberos() throws Exception {
+    setCustomAuthWithKrbOverlay(true);
+    startMiniHS2();
 
+    // JDBC connection with ID/PASSWD with SSL with Kerberos
+    String url = getJdbcUrl(true);
 
-    @BeforeClass
-    public static void beforeTest() throws Exception {
-        Class.forName(MiniHS2.getJdbcDriverName());
+    // wrong ID/PASSWD
+    try {
+      hs2Conn = DriverManager.getConnection(url, "wronguser", "pwd");
+    } catch (Exception e) {
+      assertNotNull(e.getMessage());
+      assertTrue(e.getMessage(), e.getMessage().contains("HTTP Response code: 401"));
     }
 
-    @Before
-    public void setUp() throws Exception {
-        DriverManager.setLoginTimeout(0);
-        hiveConf = new HiveConf();
-        hiveConf.setVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE, MiniHS2.HS2_HTTP_MODE);
+    // success ID/PASSWD
+    hs2Conn = DriverManager.getConnection(url, "hiveuser", "hive");
+  }
+
+  private void setCustomAuthWithKrbOverlay(boolean isSslUsed) {
+    confOverlay = new HashMap<String, String>();
+    confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_USED.varname, "true");
+    confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS.varname,
+        "org.apache.hive.minikdc.TestJdbWithCustomAuthWithKerberos$SimpleCustomAuthWithKerberosProviderImpl");
+    if (isSslUsed) {
+      // Custom class over SSL with Kerberos
+      confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED.varname, "true");
+      confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PATH.varname,
+          dataFileDir + File.separator + KEY_STORE_NAME);
+      confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PASSWORD.varname,
+          KEY_STORE_PASSWORD);
+      confOverlay.put(ConfVars.HIVE_SERVER2_USE_SSL.varname, "true");
+      confOverlay.put(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PATH.varname,
+          dataFileDir + File.separator + KEY_STORE_NAME);
+      confOverlay.put(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname,
+          KEY_STORE_PASSWORD);
+    } else {
+      confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED.varname, "false");
     }
+  }
 
-    @After
-    public void tearDown() throws Exception {
-        if (hs2Conn != null) {
-            hs2Conn.close();
-            hs2Conn = null;
-        }
-        if (miniHS2 != null && miniHS2.isStarted()) {
-            miniHS2.stop();
-            miniHS2.cleanup();
-        }
-        System.clearProperty(JAVA_TRUST_STORE_PROP);
-        System.clearProperty(JAVA_TRUST_STORE_PASS_PROP);
+  private void startMiniHS2() {
+    try {
+      miniHiveKdc = MiniHiveKdc.getMiniHiveKdc(hiveConf);
+      miniHS2 = MiniHiveKdc.getMiniHS2WithKerb(miniHiveKdc, hiveConf);
+      miniHS2.start(confOverlay);
+    } catch (Exception e) {
+      e.printStackTrace();
+      assertNotNull(e.getMessage());
     }
-
-    @Test
-    public void testKerberosAuthentication() throws Exception {
-        setCustomAuthWithKrbOverlay(false);
-        startMiniHS2();
-
-        // JDBC connection to HiveServer2 with Kerberos
-        hs2Conn = DriverManager.getConnection(miniHS2.getJdbcURL());
-    }
-
-
-    @Test
-    public void testCustomAuthenticationOverPlainWithKerberos() throws Exception {
-        setCustomAuthWithKrbOverlay(false);
-        startMiniHS2();
-
-        // JDBC connection with ID/PASSWD without SSL with Kerberos
-        String url = getJDBCURL(false);
-
-        // wrong ID/PASSWD
-        try {
-            hs2Conn = DriverManager.getConnection(url, "wronguser", "pwd");
-        } catch (Exception e) {
-            assertNotNull(e.getMessage());
-            assertTrue(e.getMessage(), e.getMessage().contains("HTTP Response code: 401"));
-        }
-
-        // success ID/PASSWD
-        hs2Conn = DriverManager.getConnection(url, "hiveuser", "hive");
-    }
-
-
-    @Test
-    public void testCustomAuthenticationOverSSLWithKerberos() throws Exception {
-        setCustomAuthWithKrbOverlay(true);
-        startMiniHS2();
-
-        String url = getJDBCURL(true);
-        // wrong ID/PASSWD
-
-        try {
-            hs2Conn = DriverManager.getConnection(url, "wronguser", "pwd");
-        } catch (Exception e) {
-            assertNotNull(e.getMessage());
-            assertTrue(e.getMessage(), e.getMessage().contains("HTTP Response code: 401"));
-        }
-
-        // success ID/PASSWD
-        hs2Conn = DriverManager.getConnection(url, "hiveuser", "hive");
-    }
-
-
-    public static class SimpleCustomAuthWithKerberosProviderImpl implements KrbCustomAuthenticationProvider {
-
-        private Map<String, String> userMap = new HashMap<String, String>();
-
-        public SimpleCustomAuthWithKerberosProviderImpl() {
-            init();
-        }
-
-        private void init() {
-            userMap.put("hiveuser", "hive");
-        }
-
-        @Override
-        public void authenticate(String user, String password) throws AuthenticationException {
-            if (!userMap.containsKey(user)) {
-                throw new AuthenticationException("Invalid user : " + user);
-            }
-            if (!userMap.get(user).equals(password)) {
-                throw new AuthenticationException("Invalid passwd : " + password);
-            }
-        }
-    }
-
-    private void setCustomAuthWithKrbOverlay(boolean ssl_used) {
-        confOverlay = new HashMap<String, String>();
-        confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_USED.varname, "true");
-        confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS.varname,
-                "org.apache.hive.minikdc.TestJdbWithCustomAuthWithKerberos$SimpleCustomAuthWithKerberosProviderImpl");
-
-        if (ssl_used) {
-            // Custom class over SSL with Kerberos
-            confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED.varname, "true");
-            confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PATH.varname,
-                    dataFileDir + File.separator + KEY_STORE_NAME);
-            confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PASSWORD.varname,
-                    KEY_STORE_PASSWORD);
-            confOverlay.put(ConfVars.HIVE_SERVER2_USE_SSL.varname, "true");
-            confOverlay.put(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PATH.varname,
-                    dataFileDir + File.separator + KEY_STORE_NAME);
-            confOverlay.put(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname,
-                    KEY_STORE_PASSWORD);
-        } else {
-            confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED.varname, "false");
-        }
-
-    }
-
-    private void startMiniHS2() {
-        try {
-            miniHiveKdc = MiniHiveKdc.getMiniHiveKdc(hiveConf);
-            miniHS2 = MiniHiveKdc.getMiniHS2WithKerb(miniHiveKdc, hiveConf);
-            miniHS2.start(confOverlay);
-        } catch (Exception e) {
-            assertNotNull(e.getMessage());
-        }
-    }
+  }
 
 }

--- a/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestJdbWithCustomAuthHttpWithKerberos.java
+++ b/itests/hive-minikdc/src/test/java/org/apache/hive/minikdc/TestJdbWithCustomAuthHttpWithKerberos.java
@@ -1,0 +1,189 @@
+package org.apache.hive.minikdc;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.thrift.KrbCustomAuthenticationProvider;
+import org.apache.hive.jdbc.TestSSL;
+import org.apache.hive.jdbc.miniHS2.MiniHS2;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.sasl.AuthenticationException;
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestJdbWithCustomAuthHttpWithKerberos {
+
+    protected String getJDBCURL(boolean isSSL) {
+        if (isSSL) {
+            // JDBC connection with ID/PASSWD over SSL with Kerberos (Custom class)
+            String url = "jdbc:hive2://" + miniHS2.getHost() + ":" + miniHS2.getHttpPort() + "/default;transportMode=http;httpPath=cliservice;http.header.x-http-authtype=Basic"
+                    + ";ssl=true;sslTrustStore=" + dataFileDir + File.separator + TRUST_STORE_NAME
+                    + ";trustStorePassword=" + KEY_STORE_PASSWORD;
+            return url;
+        } else {
+            return "jdbc:hive2://" + miniHS2.getHost() + ":" + miniHS2.getHttpPort() + "/default;transportMode=http;httpPath=cliservice;http.header.x-http-authtype=Basic";
+        }
+
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestSSL.class);
+    private static final String KEY_STORE_NAME = "keystore.jks";
+    protected static final String TRUST_STORE_NAME = "truststore.jks";
+    protected static final String KEY_STORE_PASSWORD = "HiveJdbc";
+    private static final String JAVA_TRUST_STORE_PROP = "javax.net.ssl.trustStore";
+    private static final String JAVA_TRUST_STORE_PASS_PROP = "javax.net.ssl.trustStorePassword";
+
+    private MiniHiveKdc miniHiveKdc;
+    protected static MiniHS2 miniHS2 = null;
+    private static Connection hs2Conn = null;
+    protected static HiveConf hiveConf = new HiveConf();
+    private Map<String, String> confOverlay;
+    protected String dataFileDir = hiveConf.get("test.data.files");
+
+
+    @BeforeClass
+    public static void beforeTest() throws Exception {
+        Class.forName(MiniHS2.getJdbcDriverName());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        DriverManager.setLoginTimeout(0);
+        hiveConf = new HiveConf();
+        hiveConf.setVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE, MiniHS2.HS2_HTTP_MODE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (hs2Conn != null) {
+            hs2Conn.close();
+            hs2Conn = null;
+        }
+        if (miniHS2 != null && miniHS2.isStarted()) {
+            miniHS2.stop();
+            miniHS2.cleanup();
+        }
+        System.clearProperty(JAVA_TRUST_STORE_PROP);
+        System.clearProperty(JAVA_TRUST_STORE_PASS_PROP);
+    }
+
+    @Test
+    public void testKerberosAuthentication() throws Exception {
+        setCustomAuthWithKrbOverlay(false);
+        startMiniHS2();
+
+        // JDBC connection to HiveServer2 with Kerberos
+        hs2Conn = DriverManager.getConnection(miniHS2.getJdbcURL());
+    }
+
+
+    @Test
+    public void testCustomAuthenticationOverPlainWithKerberos() throws Exception {
+        setCustomAuthWithKrbOverlay(false);
+        startMiniHS2();
+
+        // JDBC connection with ID/PASSWD without SSL with Kerberos
+        String url = getJDBCURL(false);
+
+        // wrong ID/PASSWD
+        try {
+            hs2Conn = DriverManager.getConnection(url, "wronguser", "pwd");
+        } catch (Exception e) {
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(), e.getMessage().contains("HTTP Response code: 401"));
+        }
+
+        // success ID/PASSWD
+        hs2Conn = DriverManager.getConnection(url, "hiveuser", "hive");
+    }
+
+
+    @Test
+    public void testCustomAuthenticationOverSSLWithKerberos() throws Exception {
+        setCustomAuthWithKrbOverlay(true);
+        startMiniHS2();
+
+        String url = getJDBCURL(true);
+        // wrong ID/PASSWD
+
+        try {
+            hs2Conn = DriverManager.getConnection(url, "wronguser", "pwd");
+        } catch (Exception e) {
+            assertNotNull(e.getMessage());
+            assertTrue(e.getMessage(), e.getMessage().contains("HTTP Response code: 401"));
+        }
+
+        // success ID/PASSWD
+        hs2Conn = DriverManager.getConnection(url, "hiveuser", "hive");
+    }
+
+
+    public static class SimpleCustomAuthWithKerberosProviderImpl implements KrbCustomAuthenticationProvider {
+
+        private Map<String, String> userMap = new HashMap<String, String>();
+
+        public SimpleCustomAuthWithKerberosProviderImpl() {
+            init();
+        }
+
+        private void init() {
+            userMap.put("hiveuser", "hive");
+        }
+
+        @Override
+        public void authenticate(String user, String password) throws AuthenticationException {
+            if (!userMap.containsKey(user)) {
+                throw new AuthenticationException("Invalid user : " + user);
+            }
+            if (!userMap.get(user).equals(password)) {
+                throw new AuthenticationException("Invalid passwd : " + password);
+            }
+        }
+    }
+
+    private void setCustomAuthWithKrbOverlay(boolean ssl_used) {
+        confOverlay = new HashMap<String, String>();
+        confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_USED.varname, "true");
+        confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS.varname,
+                "org.apache.hive.minikdc.TestJdbWithCustomAuthWithKerberos$SimpleCustomAuthWithKerberosProviderImpl");
+
+        if (ssl_used) {
+            // Custom class over SSL with Kerberos
+            confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED.varname, "true");
+            confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PATH.varname,
+                    dataFileDir + File.separator + KEY_STORE_NAME);
+            confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_KEYSTORE_PASSWORD.varname,
+                    KEY_STORE_PASSWORD);
+            confOverlay.put(ConfVars.HIVE_SERVER2_USE_SSL.varname, "true");
+            confOverlay.put(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PATH.varname,
+                    dataFileDir + File.separator + KEY_STORE_NAME);
+            confOverlay.put(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname,
+                    KEY_STORE_PASSWORD);
+        } else {
+            confOverlay.put(ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_SSL_USED.varname, "false");
+        }
+
+    }
+
+    private void startMiniHS2() {
+        try {
+            miniHiveKdc = MiniHiveKdc.getMiniHiveKdc(hiveConf);
+            miniHS2 = MiniHiveKdc.getMiniHS2WithKerb(miniHiveKdc, hiveConf);
+            miniHS2.start(confOverlay);
+        } catch (Exception e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+}

--- a/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
+++ b/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
@@ -121,6 +121,8 @@ public class MiniHS2 extends AbstractHiveService {
 
     public Builder withConf(HiveConf hiveConf) {
       this.hiveConf = hiveConf;
+      if(hiveConf.getVar(ConfVars.HIVE_SERVER2_TRANSPORT_MODE).equalsIgnoreCase(HS2_HTTP_MODE))
+        return withHTTPTransport();
       return this;
     }
 

--- a/service/src/java/org/apache/hive/service/auth/AuthenticationProviderFactory.java
+++ b/service/src/java/org/apache/hive/service/auth/AuthenticationProviderFactory.java
@@ -30,6 +30,7 @@ public final class AuthenticationProviderFactory {
     LDAP("LDAP"),
     PAM("PAM"),
     CUSTOM("CUSTOM"),
+    KERBEROS("KERBEROS"),
     NONE("NONE");
 
     private final String authMethod;
@@ -66,6 +67,8 @@ public final class AuthenticationProviderFactory {
       return new LdapAuthenticationProviderImpl(conf);
     } else if (authMethod == AuthMethods.PAM) {
       return new PamAuthenticationProviderImpl(conf);
+    } else if (authMethod == AuthMethods.KERBEROS) {
+      return new CustomAuthWithKerberosImpl(conf);
     } else if (authMethod == AuthMethods.CUSTOM) {
       return new CustomAuthenticationProviderImpl(conf);
     } else if (authMethod == AuthMethods.NONE) {

--- a/service/src/java/org/apache/hive/service/auth/CustomAuthWithKerberosImpl.java
+++ b/service/src/java/org/apache/hive/service/auth/CustomAuthWithKerberosImpl.java
@@ -1,0 +1,40 @@
+package org.apache.hive.service.auth;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.thrift.KrbCustomAuthenticationProvider;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.sasl.AuthenticationException;
+import java.lang.reflect.InvocationTargetException;
+
+public class CustomAuthWithKerberosImpl implements PasswdAuthenticationProvider {
+    private final KrbCustomAuthenticationProvider customProvider ;
+    public static final Logger LOG = LoggerFactory.getLogger(CustomAuthWithKerberosImpl.class.getName());
+
+    @SuppressWarnings("unchecked")
+    CustomAuthWithKerberosImpl(HiveConf conf) {
+        Class<? extends KrbCustomAuthenticationProvider> customHandlerClass =
+                (Class<? extends KrbCustomAuthenticationProvider>) conf.getClass(
+                        HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS.varname,
+                        KrbCustomAuthenticationProvider.class);
+        KrbCustomAuthenticationProvider customProvider =   null;
+        try {
+            customProvider = customHandlerClass.getConstructor(HiveConf.class).newInstance(conf);
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            try {
+                customProvider = ReflectionUtils.newInstance(customHandlerClass, conf);
+            } catch (Exception error) {
+                LOG.error("Error fetching instance of custom kerberos auth instance", error);
+            }
+
+        }
+        this.customProvider = customProvider;
+    }
+
+    @Override
+    public void Authenticate(String user, String password) throws AuthenticationException {
+        customProvider.authenticate(user, password);
+    }
+}

--- a/service/src/java/org/apache/hive/service/auth/CustomAuthWithKerberosImpl.java
+++ b/service/src/java/org/apache/hive/service/auth/CustomAuthWithKerberosImpl.java
@@ -1,40 +1,40 @@
 package org.apache.hive.service.auth;
 
+import java.lang.reflect.InvocationTargetException;
+
+import javax.security.sasl.AuthenticationException;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.thrift.KrbCustomAuthenticationProvider;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.security.sasl.AuthenticationException;
-import java.lang.reflect.InvocationTargetException;
-
 public class CustomAuthWithKerberosImpl implements PasswdAuthenticationProvider {
-    private final KrbCustomAuthenticationProvider customProvider ;
-    public static final Logger LOG = LoggerFactory.getLogger(CustomAuthWithKerberosImpl.class.getName());
+  private final KrbCustomAuthenticationProvider customProvider;
+  public static final Logger LOG = LoggerFactory.getLogger(CustomAuthWithKerberosImpl.class.getName());
 
-    @SuppressWarnings("unchecked")
-    CustomAuthWithKerberosImpl(HiveConf conf) {
-        Class<? extends KrbCustomAuthenticationProvider> customHandlerClass =
-                (Class<? extends KrbCustomAuthenticationProvider>) conf.getClass(
-                        HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS.varname,
-                        KrbCustomAuthenticationProvider.class);
-        KrbCustomAuthenticationProvider customProvider =   null;
-        try {
-            customProvider = customHandlerClass.getConstructor(HiveConf.class).newInstance(conf);
-        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            try {
-                customProvider = ReflectionUtils.newInstance(customHandlerClass, conf);
-            } catch (Exception error) {
-                LOG.error("Error fetching instance of custom kerberos auth instance", error);
-            }
-
-        }
-        this.customProvider = customProvider;
+  @SuppressWarnings("unchecked")
+  CustomAuthWithKerberosImpl(HiveConf conf) {
+    Class<? extends KrbCustomAuthenticationProvider> customHandlerClass =
+        (Class<? extends KrbCustomAuthenticationProvider>) conf.getClass(
+            HiveConf.ConfVars.HIVE_SERVER2_KERBEROS_CUSTOM_AUTH_CLASS.varname,
+            KrbCustomAuthenticationProvider.class);
+    KrbCustomAuthenticationProvider customProvider = null;
+    try {
+      customProvider = customHandlerClass.getConstructor(HiveConf.class).newInstance(conf);
+    } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      try {
+        customProvider = ReflectionUtils.newInstance(customHandlerClass, conf);
+      } catch (Exception error) {
+        LOG.error("Error fetching instance of custom kerberos auth instance", error);
+      }
     }
+    this.customProvider = customProvider;
+  }
 
-    @Override
-    public void Authenticate(String user, String password) throws AuthenticationException {
-        customProvider.authenticate(user, password);
-    }
+  @Override
+  public void Authenticate(String user, String password) throws AuthenticationException {
+    customProvider.authenticate(user, password);
+  }
 }

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
@@ -357,7 +357,7 @@ public class ThriftHttpServlet extends TServlet {
     // No-op when authType is NOSASL
     if (!authType.equalsIgnoreCase(HiveAuthFactory.AuthTypes.NOSASL.toString())) {
       try {
-        //Check if sap auth header is present and if so use this custom class that we created
+        //Check if http auth header is present and if so use this custom class that we created
         AuthMethods authMethod = AuthMethods.getValidAuthMethod(authType);
         PasswdAuthenticationProvider provider =
             AuthenticationProviderFactory.getAuthenticationProvider(authMethod, hiveConf);


### PR DESCRIPTION
1. Basic auth is supported with http channel for hive jwt token with additional header "X-SAP-Hive-PasswdAuth" set to true
2. New class added to support this password authentication provider
3. I tested this successfully in cluster(naren4635) with this
beeline -u "jdbc:hive2://hiveserver-naren4635.test.altiscale.com:10001/default;transportMode=http;httpPath=cliservice;http.header.X-SAP-Hive-PasswdAuth=true;http.header.Authorization=Basic <username>:<jwtoken>"
Note that you don't need to do basic 64 encoding in the above as the beeline automatically does this for you.
Thanks,
Narendra